### PR TITLE
from location: Type 로케이션 dto 리팩토링, + Enum value, 변수 네이밍 변경

### DIFF
--- a/src/main/java/com/trablock/web/controller/LocationController.java
+++ b/src/main/java/com/trablock/web/controller/LocationController.java
@@ -1,15 +1,16 @@
 package com.trablock.web.controller;
 
-import com.trablock.web.dto.location.*;
+import com.trablock.web.dto.location.BlockLocationDto;
+import com.trablock.web.dto.location.LocationTypeDto;
+import com.trablock.web.dto.location.LocationWrapperDto;
+import com.trablock.web.dto.location.MarkLocationDto;
 import com.trablock.web.dto.location.type.TypeLocationDto;
 import com.trablock.web.service.location.LocationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/trablock/web/controller/LocationController.java
+++ b/src/main/java/com/trablock/web/controller/LocationController.java
@@ -1,6 +1,7 @@
 package com.trablock.web.controller;
 
 import com.trablock.web.dto.location.*;
+import com.trablock.web.dto.location.type.TypeLocationDto;
 import com.trablock.web.service.location.LocationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,7 +26,7 @@ public class LocationController {
      */
     @ResponseBody
     @RequestMapping(value = "/locations/{locationId}", method = RequestMethod.GET)
-    public ResponseEntity<Object> viewLocationDetails(@PathVariable("locationId") Long locationId, @RequestBody LocationTypeDto locationTypeDto) {
+    public ResponseEntity<TypeLocationDto> viewLocationDetails(@PathVariable("locationId") Long locationId, @RequestBody LocationTypeDto locationTypeDto) {
         return ResponseEntity.ok(locationService.getLocationDetails(locationId, locationTypeDto.getType()));
     }
 

--- a/src/main/java/com/trablock/web/domain/LocationType.java
+++ b/src/main/java/com/trablock/web/domain/LocationType.java
@@ -3,16 +3,15 @@ package com.trablock.web.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum LocationType {
-    ATTRACTION("ATTRACTION"),
-    CULTURE("CULTURE"),
-    FESTIVAL("FESTIVAL"),
-    LEPORTS("LEPORTS"),
-    LODGE("LODGE"),
-    RESTAURANT("RESTAURANT");
+    ATTRACTION("Attraction"),
+    CULTURE("Culture"),
+    FESTIVAL("Festival"),
+    LEPORTS("Leports"),
+    LODGE("Lodge"),
+    RESTAURANT("restaurant");
 
     private String type;
 

--- a/src/main/java/com/trablock/web/dto/location/BlockLocationDto.java
+++ b/src/main/java/com/trablock/web/dto/location/BlockLocationDto.java
@@ -14,7 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class BlockLocationDto {
 
-    private Long id;
+    private Long locationId;
     private String name;
     private String address1;
     private String address2;

--- a/src/main/java/com/trablock/web/dto/location/LocationDto.java
+++ b/src/main/java/com/trablock/web/dto/location/LocationDto.java
@@ -11,7 +11,7 @@ import static lombok.AccessLevel.*;
 @NoArgsConstructor(access = PROTECTED)
 public class LocationDto {
 
-    private Long id;
+    private Long locationId;
     private String name;
     private String address1;
     private String address2;

--- a/src/main/java/com/trablock/web/dto/location/MarkLocationDto.java
+++ b/src/main/java/com/trablock/web/dto/location/MarkLocationDto.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.*;
 @NoArgsConstructor(access = PROTECTED)
 public class MarkLocationDto {
 
-    private Long id;
+    private Long locationId;
     private String name;
     private Coords coords;
     private LocationType type;

--- a/src/main/java/com/trablock/web/dto/location/type/AttractionDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/AttractionDto.java
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class AttractionDto {
+public class AttractionDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;
@@ -28,5 +28,6 @@ public class AttractionDto {
 
     private boolean parking;
     private String restDate;
+    private String useTime;
 
 }

--- a/src/main/java/com/trablock/web/dto/location/type/CultureDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/CultureDto.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class CultureDto {
+public class CultureDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;

--- a/src/main/java/com/trablock/web/dto/location/type/FestivalDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/FestivalDto.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class FestivalDto {
+public class FestivalDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;

--- a/src/main/java/com/trablock/web/dto/location/type/LeportsDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/LeportsDto.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class LeportsDto {
+public class LeportsDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;

--- a/src/main/java/com/trablock/web/dto/location/type/LodgeDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/LodgeDto.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class LodgeDto {
+public class LodgeDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;

--- a/src/main/java/com/trablock/web/dto/location/type/RestaurantDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/RestaurantDto.java
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class RestaurantDto {
+public class RestaurantDto extends TypeLocationDto {
 
     private Long locationId;
     private String name;

--- a/src/main/java/com/trablock/web/dto/location/type/TypeLocationDto.java
+++ b/src/main/java/com/trablock/web/dto/location/type/TypeLocationDto.java
@@ -1,0 +1,5 @@
+package com.trablock.web.dto.location.type;
+
+public abstract class TypeLocationDto {
+
+}

--- a/src/main/java/com/trablock/web/entity/location/Location.java
+++ b/src/main/java/com/trablock/web/entity/location/Location.java
@@ -63,7 +63,7 @@ public class Location {
 
     public BlockLocationDto toBlockLocationDto() {
         return BlockLocationDto.builder()
-                .id(id)
+                .locationId(id)
                 .name(name)
                 .address1(address1)
                 .address2(address2)
@@ -74,7 +74,7 @@ public class Location {
 
     public MarkLocationDto toMarkLocationDto() {
         return MarkLocationDto.builder()
-                .id(id)
+                .locationId(id)
                 .name(name)
                 .coords(coords)
                 .type(type)

--- a/src/main/java/com/trablock/web/repository/location/LocationRepositoryCustomImpl.java
+++ b/src/main/java/com/trablock/web/repository/location/LocationRepositoryCustomImpl.java
@@ -66,7 +66,8 @@ public class LocationRepositoryCustomImpl implements LocationRepositoryCustom {
                         information.report,
                         location.type,
                         attraction.parking,
-                        attraction.restDate
+                        attraction.restDate,
+                        attraction.useTime
                 )).from(location)
                 .leftJoin(attraction).on(location.id.eq(attraction.locationId))
                 .leftJoin(information).on(location.id.eq(information.locationId))

--- a/src/main/java/com/trablock/web/service/location/LocationService.java
+++ b/src/main/java/com/trablock/web/service/location/LocationService.java
@@ -4,18 +4,17 @@ import com.trablock.web.domain.LocationType;
 import com.trablock.web.dto.location.*;
 import com.trablock.web.dto.location.save.InformationRequestDto;
 import com.trablock.web.dto.location.save.MemberLocationRequestDto;
+import com.trablock.web.dto.location.type.TypeLocationDto;
 import com.trablock.web.entity.location.Location;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 public interface LocationService {
 
-    Object getLocationDetails(Long locationId, LocationType locationType);
+    TypeLocationDto getLocationDetails(Long locationId, LocationType locationType);
 
     Long createLocationByMember(LocationWrapperDto wrapperDto);
 

--- a/src/main/java/com/trablock/web/service/location/LocationServiceImpl.java
+++ b/src/main/java/com/trablock/web/service/location/LocationServiceImpl.java
@@ -4,6 +4,7 @@ import com.trablock.web.domain.LocationType;
 import com.trablock.web.dto.location.*;
 import com.trablock.web.dto.location.save.InformationRequestDto;
 import com.trablock.web.dto.location.save.MemberLocationRequestDto;
+import com.trablock.web.dto.location.type.TypeLocationDto;
 import com.trablock.web.entity.location.Location;
 import com.trablock.web.entity.location.type.*;
 import com.trablock.web.repository.location.InformationRepository;
@@ -134,7 +135,7 @@ public class LocationServiceImpl implements LocationService {
     }
 
     @Override
-    public Object getLocationDetails(Long locationId, LocationType locationType) {
+    public TypeLocationDto getLocationDetails(Long locationId, LocationType locationType) {
         switch (locationType) {
             case ATTRACTION:
                 return locationRepository.findAttractionByLocationId(locationId);


### PR DESCRIPTION
### + 문제상황 : Location의 Details를 반환할 때 Object 타입으로 반환하고 있었음
=> null로 반환되는 경우에도 예외처리가 되지 않을 수 있음

다음과 같은 방식으로 해결
0. 기존의 타입 로케이션 DTO들을 TypeLocationDto라는 abstract class를 만들어 상속시킴.
1. Service 레이어와 Controller 레이어에서 해당 메소드 반환 값을 Object에서 TypeLocationDto로 변경.
2. 문제 해결

### ++ 이후 개선사항
abstract class인 TypeLocation에서 중복되는 일부 property를 상속하고 싶었으나, 테스트 시 오류 발생. 원인을 찾으면 수정 가능할 것으로 보임.

### +++ enum value, 변수 네이밍 변경
0. Type Enum의 value를 첫 글자만 capital로 변경.
1. Location 관련 dto에서 id를 locationId로 명명 변경

